### PR TITLE
[클린코드 리액트 1기 임유리] 페이먼츠 미션 Step 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yarn-error.log
 build-storybook.log
 .vscode
 storybook-static
+.DS_Store

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,39 @@
-import { createContext } from 'react';
+import { useRef, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import styled from 'styled-components';
+import { CardContext } from '@/context/cardContext';
 import PageContainer from '@components/PageContainer';
 import NewCard from '@/pages/NewCard';
 import List from '@/pages/List';
 import Done from '@/pages/Done';
 import { INIT_CARD_STATE } from '@/constants/index';
 
-const CardContext = createContext({});
-
 function App() {
+  const [cardState, setCardState] = useState(INIT_CARD_STATE);
+  const [cardList, setCardList] = useState([] as typeof cardState[]);
+
   return (
-    <Root>
-      <CardContext.Provider value={INIT_CARD_STATE}>
+    <CardContext.Provider
+      value={{ cardState, setCardState, cardList, setCardList }}
+    >
+      <Root>
         <Routes>
           <Route path='/' element={<List />} />
           <Route path='list' element={<List />} />
           <Route path='new' element={<NewCard />} />
-          <Route path='done' element={<Done />} />
+          <Route path='done' element={<Done />}>
+            <Route path=':id' element={<Done />} />
+          </Route>
+          <Route path='edit' element={<Done />}>
+            <Route path=':id' element={<Done />} />
+          </Route>
           <Route
             path='*'
             element={<PageContainer>Not Found Page 🙅</PageContainer>}
           />
         </Routes>
-      </CardContext.Provider>
-    </Root>
+      </Root>
+    </CardContext.Provider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import styled from 'styled-components';
 import { CardContext } from '@/context/cardContext';

--- a/src/components/Button/buttonStyle.ts
+++ b/src/components/Button/buttonStyle.ts
@@ -1,7 +1,11 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const ButtonEl = styled.button`
+export const ButtonEl = styled.button<{ disabled?: boolean }>`
   background: transparent;
   cursor: pointer;
-  color: #383838;
+
+  ${({ disabled }) => css`
+    color: ${disabled ? '#c6c6c9' : '#383838'};
+    cursor: ${disabled ? 'not-allowed' : 'pointer'};
+  `}
 `;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import { VFC, ReactNode } from 'react';
+import { FC } from 'react';
 import { ButtonEl } from './buttonStyle';
 
 export interface ButtonProps
@@ -8,13 +8,20 @@ export interface ButtonProps
     >,
     React.AriaAttributes {}
 
-const Button: VFC<
-  ButtonProps & {
-    children: ReactNode;
-  }
-> = ({ className = '', children, type = 'submit', onClick }) => {
+const Button: FC<ButtonProps> = ({
+  className = '',
+  children,
+  type = 'submit',
+  onClick,
+  disabled = false,
+}) => {
   return (
-    <ButtonEl type={type} className={className} onClick={onClick}>
+    <ButtonEl
+      type={type}
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+    >
       {children}
     </ButtonEl>
   );

--- a/src/components/Card/cardStyle.ts
+++ b/src/components/Card/cardStyle.ts
@@ -103,3 +103,40 @@ export const CardText = styled.span<{
     `}
   `}
 `;
+
+export const CardItemWrap = styled.div`
+  position: relative;
+  margin-bottom: 16px;
+  a {
+    color: #575757;
+  }
+  .card-nickname {
+    text-align: center;
+  }
+  .btn-delete {
+    position: absolute;
+    top: 1rem;
+    left: -2rem;
+    display: inline-flex;
+    align-items: center;
+    align-content: center;
+    width: 20px;
+    height: 20px;
+    font-size: 0;
+    box-shadow: 3px 3px 5px rgb(0 0 0 / 25%);
+    border-radius: 10px;
+    border: 1px solid #bf2727;
+    text-align: center;
+    &:before {
+      width: 20px;
+      height: 20px;
+
+      color: #bf2727;
+      box-sizing: border-box;
+      line-height: 20px;
+      font-size: 1.5rem;
+      font-weight: 700;
+      content: '-';
+    }
+  }
+`;

--- a/src/components/Card/type.ts
+++ b/src/components/Card/type.ts
@@ -3,6 +3,7 @@ import { CVC, PASSWORD, NICKNAME } from '@/constants/index';
 export type cardSize = 'small' | 'big';
 
 export interface initCardState {
+  id: number;
   company: string;
   cardNumber: (number | string)[];
   owner: string;

--- a/src/components/Forms/InputContainer/index.tsx
+++ b/src/components/Forms/InputContainer/index.tsx
@@ -12,7 +12,7 @@ const InputContainer: FC<{
   isError?: boolean;
 }> = ({ title = '', titleAfterNode, children, isError, ...others }) => {
   return (
-    <InputContainerEl {...others}>
+    <InputContainerEl isError={isError} {...others}>
       <InputLabel>
         {title && <InputTitle isError={isError}>{title}</InputTitle>}
         {title && titleAfterNode}

--- a/src/components/Forms/InputContainer/inputContainerStyle.ts
+++ b/src/components/Forms/InputContainer/inputContainerStyle.ts
@@ -1,7 +1,17 @@
 import styled, { css } from 'styled-components';
 
-export const InputContainerEl = styled.div`
+export const InputContainerEl = styled.div<{ isError?: boolean }>`
   margin: 16px 0;
+
+  .error-message {
+    ${({ isError }) => css`
+      margin-top: 4px;
+      font-size: 12px;
+      line-height: 14px;
+      height: 14px;
+      ${isError ? `color: red;` : ''}
+    `}
+  }
 `;
 
 export const InputLabel = styled.label`

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { useContext, FC } from 'react';
 import {
   ModalDimmed,
   ModalEl,
@@ -7,19 +7,50 @@ import {
   ModalItemDot,
   ModalItemName,
 } from './modalStyle';
-import { newStateProps, changeCardStateType } from '@/pages/NewCard/type';
+import { CardContext } from '@/context/cardContext';
 import Button from '@components/Button';
 
-const data = Array(8).fill({
-  name: '클린 카드',
-  color: '#baefe6',
-});
+const data = [
+  {
+    name: '클린 카드',
+    color: '#baefe6',
+  },
+  {
+    name: '우리 카드',
+    color: '#c1d7f9',
+  },
+  {
+    name: '신한 카드',
+    color: '#efe8ba',
+  },
+  {
+    name: '카뱅 카드',
+    color: '#ffdb57',
+  },
+  {
+    name: '토스 카드',
+    color: '#9195fd',
+  },
+  {
+    name: '국민 카드',
+    color: '#cf933a',
+  },
+  {
+    name: '기업 카드',
+    color: '#92a8bf',
+  },
+  {
+    name: '농협 카드',
+    color: '#b4e7a3',
+  },
+];
 
 const Modal: FC<{
   className?: string;
-  changeCardState: changeCardStateType;
   onClose: () => void;
-}> = ({ changeCardState, onClose }) => {
+}> = ({ onClose }) => {
+  const { cardState, setCardState } = useContext(CardContext);
+
   return (
     <ModalDimmed onClick={onClose}>
       <ModalEl>
@@ -28,10 +59,11 @@ const Modal: FC<{
             <Button
               key={i}
               onClick={() => {
-                changeCardState({
+                setCardState({
+                  ...cardState,
                   bgColor: color,
                   company: name,
-                } as newStateProps);
+                });
               }}
             >
               <ModalItem>

--- a/src/components/Modal/modalStyle.ts
+++ b/src/components/Modal/modalStyle.ts
@@ -19,8 +19,8 @@ export const ModalEl = styled.div`
   width: 100%;
   height: 220px;
   margin-top: auto;
-  padding: 0 0 calc(constant(safe-area-inset-bottom) + 100px);
-  padding: 0 0 calc(env(safe-area-inset-bottom) + 100px);
+  padding-bottom: calc(1rem + constant(safe-area-inset-bottom));
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom));
 
   border-radius: 5px 5px 0 0;
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 import { initCardState } from '@components/Card/type';
 
+export const CARD_ID = 'id';
 export const CARD_NUMBER = 'cardNumber';
 export const EXPIRY_DATE = 'expiryDate';
 export const OWNER = 'owner';
@@ -18,17 +19,21 @@ export const DIGITS = {
 };
 
 export const INPUT_LENGTH: {
-  [k in keyof Omit<initCardState, typeof COMPANY | typeof BG_COLOR>]: number;
+  [k in keyof Omit<
+    initCardState,
+    typeof COMPANY | typeof BG_COLOR | typeof CARD_ID
+  >]: number;
 } = {
   [CARD_NUMBER]: 4,
   [EXPIRY_DATE]: 2,
   [OWNER]: 30,
   [PASSWORD]: 1,
   [CVC]: 3,
-  [NICKNAME]: 30,
+  [NICKNAME]: 10,
 };
 
 export const INIT_CARD_STATE: initCardState = Object.freeze({
+  [CARD_ID]: 0,
   [CARD_NUMBER]: Array(DIGITS[CARD_NUMBER]).fill(''),
   [EXPIRY_DATE]: Array(DIGITS[EXPIRY_DATE]).fill(''),
   [OWNER]: '',
@@ -39,56 +44,58 @@ export const INIT_CARD_STATE: initCardState = Object.freeze({
   [BG_COLOR]: '',
 });
 
-export const FIELD_ORDERS = Object.keys(INIT_CARD_STATE);
-
 export const INPUT_INFO = {
   [CARD_NUMBER]: {
     require: true,
     valueLength: INPUT_LENGTH[CARD_NUMBER],
     pattern: '^[0-9]+$',
+    errorMessage: {
+      invalidLength: '숫자 4자리를 입력해 주세요.',
+      invalidValue: '유효한 값이 아닙니다.',
+    },
   },
   [EXPIRY_DATE]: {
     require: true,
     valueLength: INPUT_LENGTH[EXPIRY_DATE],
     pattern: ['^(0[1-9]|1[012])$', '^[0-9]+$'],
+    errorMessage: {
+      invalidLength: '숫자 2자리를 입력해 주세요.',
+      invalidValue: [
+        '월은 1이상 12이하 숫자만 입력 가능합니다.',
+        '유효한 값이 아닙니다.',
+      ],
+    },
   },
   [OWNER]: {
     require: false,
     valueLength: INPUT_LENGTH[OWNER],
-    pattern: '',
+    pattern: '', //^[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣]+$
+    errorMessage: null,
   },
   [CVC]: {
     require: true,
     valueLength: INPUT_LENGTH[CVC],
     pattern: '^[0-9]+$',
+    errorMessage: {
+      invalidLength: '숫자 3자리를 입력해 주세요.',
+      invalidValue: '유효한 값이 아닙니다.',
+    },
   },
   [PASSWORD]: {
     require: true,
     valueLength: INPUT_LENGTH[PASSWORD],
     pattern: '^[0-9]+$',
+    errorMessage: {
+      invalidLength: '숫자로 입력해 주세요.',
+      invalidValue: '유효한 값이 아닙니다.',
+    },
   },
   [NICKNAME]: {
     require: false,
     valueLength: INPUT_LENGTH[NICKNAME],
     pattern: '',
+    errorMessage: null,
   },
 };
 
-export const ERROR_MESSAGES = {
-  [CARD_NUMBER]: {
-    invalidLength: '',
-    invalidValue: '유효한 값이 아닙니다.',
-  },
-  [EXPIRY_DATE]: {
-    invalidLength: '',
-    invalidValue: ['', ''],
-  },
-  [CVC]: {
-    invalidLength: '',
-    invalidValue: '',
-  },
-  [PASSWORD]: {
-    invalidLength: '',
-    invalidValue: '',
-  },
-};
+export const FIELD_ORDERS = Object.keys(INPUT_INFO);

--- a/src/context/cardContext.ts
+++ b/src/context/cardContext.ts
@@ -1,0 +1,16 @@
+import { createContext, Dispatch, Ref, SetStateAction } from 'react';
+import { INIT_CARD_STATE } from '@/constants/index';
+import { initCardState } from '@components/Card/index';
+
+interface CardContextType {
+  cardState: initCardState;
+  setCardState: Dispatch<SetStateAction<initCardState>>;
+  cardList: initCardState[];
+  setCardList: Dispatch<SetStateAction<initCardState[]>>;
+}
+export const CardContext = createContext<CardContextType>({
+  cardState: { ...INIT_CARD_STATE },
+  setCardState: () => null,
+  cardList: [],
+  setCardList: () => null,
+});

--- a/src/context/cardContext.ts
+++ b/src/context/cardContext.ts
@@ -1,4 +1,4 @@
-import { createContext, Dispatch, Ref, SetStateAction } from 'react';
+import { createContext, Dispatch, SetStateAction } from 'react';
 import { INIT_CARD_STATE } from '@/constants/index';
 import { initCardState } from '@components/Card/index';
 

--- a/src/helper/isValid.ts
+++ b/src/helper/isValid.ts
@@ -24,3 +24,14 @@ export const isValueValidLength = (
   value: number | string,
   fieldKey: keyof typeof INPUT_LENGTH
 ) => `${value}`?.length === INPUT_LENGTH[fieldKey];
+
+export const hasSameKey = () => {
+  const keySet = new Set();
+
+  return (newKey: string) => {
+    const hasSameKey = keySet.has(newKey);
+    if (hasSameKey) return hasSameKey;
+    keySet.add(newKey);
+    return false;
+  };
+};

--- a/src/helper/isValid.ts
+++ b/src/helper/isValid.ts
@@ -24,14 +24,3 @@ export const isValueValidLength = (
   value: number | string,
   fieldKey: keyof typeof INPUT_LENGTH
 ) => `${value}`?.length === INPUT_LENGTH[fieldKey];
-
-export const hasSameKey = () => {
-  const keySet = new Set();
-
-  return (newKey: string) => {
-    const hasSameKey = keySet.has(newKey);
-    if (hasSameKey) return hasSameKey;
-    keySet.add(newKey);
-    return false;
-  };
-};

--- a/src/hooks/useInputValidationStates.ts
+++ b/src/hooks/useInputValidationStates.ts
@@ -6,7 +6,6 @@ const useInputValidationStates = () => {
   const [validationStates, setValidationState] = useState({
     cardNumber: ['', '', '', ''],
     expiryDate: ['', ''],
-    owner: [''],
     cvc: [''],
     password: ['', ''],
   });
@@ -17,7 +16,7 @@ const useInputValidationStates = () => {
     index,
   }: {
     value: number | string;
-    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname'>;
+    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname' | 'owner'>;
     index: number;
   }) => {
     const currentValidationState =
@@ -42,7 +41,7 @@ const useInputValidationStates = () => {
     index,
   }: {
     value: number | string;
-    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname'>;
+    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname' | 'owner'>;
     index: number;
   }) =>
     isValidValue(value, fieldKey, index) && isValueValidLength(value, fieldKey);
@@ -57,7 +56,7 @@ const useInputValidationStates = () => {
     fieldKey,
     index,
   }: {
-    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname'>;
+    fieldKey: keyof Omit<typeof INPUT_INFO, 'nickname' | 'owner'>;
     index: number;
   }) => {
     const stateCode = validationStates[fieldKey][index];

--- a/src/pages/Done/index.tsx
+++ b/src/pages/Done/index.tsx
@@ -1,5 +1,7 @@
-import { useNavigate } from 'react-router-dom';
-import { NICKNAME, INPUT_LENGTH } from '@/constants/index';
+import { useContext, useRef } from 'react';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { NICKNAME, INPUT_LENGTH, INIT_CARD_STATE } from '@/constants/index';
+import { CardContext } from '@/context/cardContext';
 import PageContainer from '@components/PageContainer';
 import PageTitle from '@/components/PageTitle';
 import PageBottom, { PageBottomText } from '@components/PageBottom';
@@ -10,26 +12,50 @@ import InputContainer from '@/components/Forms/InputContainer';
 
 const Done = () => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { id } = useParams();
+  const { setCardState, cardList, setCardList } = useContext(CardContext);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const foundCardIndex = cardList.findIndex((v) => v.id === Number(id));
+
+  const doneAddCard = () => {
+    setCardList(
+      cardList.map((v, i) =>
+        i === foundCardIndex
+          ? { ...v, [NICKNAME]: inputRef.current?.value || v.company }
+          : v
+      )
+    );
+    setCardState(INIT_CARD_STATE);
+    navigate('../list');
+  };
 
   return (
     <PageContainer className='flex-column-center'>
       <div className='flex-center'>
-        <PageTitle className='mb-10'>카드등록이 완료되었습니다.</PageTitle>
+        <PageTitle className='mb-10'>
+          {pathname.includes('done')
+            ? '카드등록이 완료되었습니다.'
+            : '카드의 별칭 수정 ✏️'}
+        </PageTitle>
       </div>
-      <Card size='big' />
+      <Card size='big' {...cardList[foundCardIndex]} />
       <InputContainer className='flex-center w-100'>
         <Input
           className='w-75'
           variant='underline'
           data-id={NICKNAME}
           maxLength={INPUT_LENGTH[NICKNAME]}
-          defaultValue=''
+          defaultValue={
+            foundCardIndex >= 0 ? cardList[foundCardIndex][NICKNAME] : ''
+          }
           placeholder='카드의 별칭을 입력해주세요.'
+          ref={inputRef}
         />
       </InputContainer>
       <PageBottom className='mt-50'>
-        <Button onClick={() => navigate('../list')}>
-          <PageBottomText>다음</PageBottomText>
+        <Button onClick={doneAddCard}>
+          <PageBottomText>확인</PageBottomText>
         </Button>
       </PageBottom>
     </PageContainer>

--- a/src/pages/List/index.tsx
+++ b/src/pages/List/index.tsx
@@ -1,21 +1,51 @@
-import { useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { CardContext } from '@/context/cardContext';
 import PageContainer from '@components/PageContainer';
 import PageTitle from '@/components/PageTitle';
-import { CardBoxEl, CardEl } from '@/components/Card';
+import Card, { CardBoxEl, CardEl, CardItemWrap } from '@/components/Card';
 import Button from '@/components/Button';
 
 const List = () => {
   const navigate = useNavigate();
+  const { cardList, setCardList } = useContext(CardContext);
+
+  const deleteCard = (cardId: number) =>
+    setCardList(cardList.filter((v) => v.id !== cardId));
 
   return (
     <PageContainer className='flex-column-center'>
       <div className='flex-center'>
         <PageTitle className='mb-10'>보유 카드</PageTitle>
       </div>
+      {cardList.map((v) => (
+        <CardItemWrap key={`card${v.id}`}>
+          <Link to={`../edit/${v.id}`}>
+            <Card {...v} />
+          </Link>
+          <div className='card-nickname'>{v.nickname}</div>
+          <Button
+            type='button'
+            className='btn-delete'
+            onClick={() => {
+              if (window.confirm(`${v.nickname}를 삭제하시겠습니까?`)) {
+                deleteCard(v.id);
+              }
+            }}
+          >
+            삭제
+          </Button>
+        </CardItemWrap>
+      ))}
       <CardBoxEl>
-        <Button onClick={() => navigate('../new')} type='button'>
-          <CardEl size='small'>+</CardEl>
-        </Button>
+        <CardEl
+          size='small'
+          onClick={() => navigate('../new')}
+          type='button'
+          as='button'
+        >
+          +
+        </CardEl>
       </CardBoxEl>
     </PageContainer>
   );

--- a/src/pages/NewCard/CardForm.stories.tsx
+++ b/src/pages/NewCard/CardForm.stories.tsx
@@ -1,8 +1,5 @@
-import { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { INIT_CARD_STATE } from '@/constants/index';
 import CardForm from '@/pages/NewCard/cardForm';
-import { changeCardStateType } from '@/pages/NewCard/type';
 
 export default {
   title: 'components/CardForm',
@@ -10,12 +7,7 @@ export default {
 } as ComponentMeta<typeof CardForm>;
 
 const Template: ComponentStory<typeof CardForm> = () => {
-  const [cardState, setCardState] = useState({ ...INIT_CARD_STATE });
-  const changeCardState: changeCardStateType = (newState) => {
-    setCardState({ ...cardState, ...newState });
-  };
-
-  return <CardForm cardState={cardState} changeCardState={changeCardState} />;
+  return <CardForm />;
 };
 
 export const newAddCardForm = Template.bind({});

--- a/src/pages/NewCard/cardForm.tsx
+++ b/src/pages/NewCard/cardForm.tsx
@@ -63,7 +63,7 @@ const CardForm = () => {
       dataset: { index, id },
     },
   }: React.ChangeEvent<HTMLInputElement>) => {
-    const fieldKey = id as keyof Omit<typeof INPUT_INFO, 'nickname'>;
+    const fieldKey = id as keyof Omit<typeof INPUT_INFO, 'nickname' | 'owner'>;
     const prevState = cardState[fieldKey];
 
     if (isValueOverMaximumLength(value, fieldKey)) return;
@@ -74,11 +74,13 @@ const CardForm = () => {
         : value,
     } as unknown as newStateProps;
 
-    setInputValidationStates({
-      value: value,
-      fieldKey,
-      index: Number(index),
-    });
+    if (INPUT_INFO[fieldKey].require) {
+      setInputValidationStates({
+        value: value,
+        fieldKey,
+        index: Number(index),
+      });
+    }
 
     setCardState({ ...cardState, ...newState });
 
@@ -105,7 +107,7 @@ const CardForm = () => {
     e.preventDefault();
 
     if (isAllValid()) {
-      const cardId = Number(cardList[cardList.length - 1]?.id || 0) + 1;
+      const cardId = Number(cardList[0]?.id || 0) + 1;
 
       setCardList([
         {

--- a/src/pages/NewCard/cardForm.tsx
+++ b/src/pages/NewCard/cardForm.tsx
@@ -1,6 +1,13 @@
-import { useState, useEffect, useContext, FormEventHandler } from 'react';
+import {
+  useState,
+  useEffect,
+  useContext,
+  FormEventHandler,
+  Fragment,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  INIT_CARD_STATE,
   CARD_NUMBER,
   EXPIRY_DATE,
   OWNER,
@@ -130,55 +137,24 @@ const CardForm = () => {
           title='카드번호'
         >
           <InputBox>
-            <Input
-              type='number'
-              data-index={0}
-              data-id={CARD_NUMBER}
-              value={cardState[CARD_NUMBER][0]}
-              pattern={INPUT_INFO[CARD_NUMBER].pattern}
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${CARD_NUMBER}${0}` ? inputRef : null
-              }
-            />
-            {cardState[CARD_NUMBER][0] && ' - '}
-            <Input
-              type='number'
-              data-index={1}
-              data-id={CARD_NUMBER}
-              value={cardState[CARD_NUMBER][1]}
-              pattern={INPUT_INFO[CARD_NUMBER].pattern}
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${CARD_NUMBER}${1}` ? inputRef : null
-              }
-            />
-            {cardState[CARD_NUMBER][1] && ' - '}
-            <Input
-              type='password'
-              data-index={2}
-              data-id={CARD_NUMBER}
-              value={cardState[CARD_NUMBER][2]}
-              maxLength={INPUT_LENGTH[CARD_NUMBER]}
-              pattern={INPUT_INFO[CARD_NUMBER].pattern}
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${CARD_NUMBER}${2}` ? inputRef : null
-              }
-            />
-            {cardState[CARD_NUMBER][2] && ' - '}
-            <Input
-              type='password'
-              data-index={3}
-              data-id={CARD_NUMBER}
-              value={cardState[CARD_NUMBER][3]}
-              maxLength={INPUT_LENGTH[CARD_NUMBER]}
-              pattern={INPUT_INFO[CARD_NUMBER].pattern}
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${CARD_NUMBER}${3}` ? inputRef : null
-              }
-            />
+            {INIT_CARD_STATE[CARD_NUMBER].map((_, i, arr) => (
+              <Fragment key={`${CARD_NUMBER}${i}`}>
+                <Input
+                  type={i < 2 ? 'number' : 'password'}
+                  data-index={i}
+                  data-id={CARD_NUMBER}
+                  value={cardState[CARD_NUMBER][i]}
+                  pattern={INPUT_INFO[CARD_NUMBER].pattern}
+                  onChange={onChangeHandler}
+                  ref={
+                    nextFieldId.current === `${CARD_NUMBER}${i}`
+                      ? inputRef
+                      : null
+                  }
+                />
+                {i !== arr.length - 1 && cardState[CARD_NUMBER][i] && ' - '}
+              </Fragment>
+            ))}
           </InputBox>
           <div className='error-message'>
             {getErrorMessage({
@@ -192,31 +168,27 @@ const CardForm = () => {
           title='만료일'
         >
           <InputBox className='w-50'>
-            <Input
-              type='number'
-              data-index={0}
-              data-id={EXPIRY_DATE}
-              value={cardState[EXPIRY_DATE][0]}
-              pattern={INPUT_INFO[EXPIRY_DATE].pattern[0]}
-              placeholder='MM'
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${EXPIRY_DATE}${0}` ? inputRef : null
-              }
-            />
-            {cardState[EXPIRY_DATE]?.every((v) => v) && ' / '}
-            <Input
-              type='number'
-              data-index={1}
-              data-id={EXPIRY_DATE}
-              value={cardState[EXPIRY_DATE][1]}
-              pattern={INPUT_INFO[EXPIRY_DATE].pattern[1]}
-              placeholder='YY'
-              onChange={onChangeHandler}
-              ref={
-                nextFieldId.current === `${EXPIRY_DATE}${1}` ? inputRef : null
-              }
-            />
+            {INIT_CARD_STATE[EXPIRY_DATE].map((_, i, arr) => (
+              <Fragment key={`${EXPIRY_DATE}${i}`}>
+                <Input
+                  type='number'
+                  data-index={i}
+                  data-id={EXPIRY_DATE}
+                  value={cardState[EXPIRY_DATE][i]}
+                  pattern={INPUT_INFO[EXPIRY_DATE].pattern[i]}
+                  placeholder={i === 0 ? 'MM' : 'YY'}
+                  onChange={onChangeHandler}
+                  ref={
+                    nextFieldId.current === `${EXPIRY_DATE}${i}`
+                      ? inputRef
+                      : null
+                  }
+                />
+                {i !== arr.length - 1 &&
+                  cardState[EXPIRY_DATE]?.every((v) => v) &&
+                  ' / '}
+              </Fragment>
+            ))}
           </InputBox>
           <div className='error-message'>
             {getErrorMessage({
@@ -268,28 +240,23 @@ const CardForm = () => {
           title='카드 비밀번호'
         >
           <>
-            <Input
-              type='password'
-              className='w-15'
-              data-index={0}
-              data-id={PASSWORD}
-              value={cardState[PASSWORD][0]}
-              maxLength={INPUT_LENGTH[PASSWORD]}
-              pattern={INPUT_INFO[PASSWORD].pattern}
-              onChange={onChangeHandler}
-              ref={nextFieldId.current === `${PASSWORD}${0}` ? inputRef : null}
-            />{' '}
-            <Input
-              type='password'
-              className='w-15'
-              data-index={1}
-              data-id={PASSWORD}
-              value={cardState[PASSWORD][1]}
-              maxLength={INPUT_LENGTH[PASSWORD]}
-              pattern={INPUT_INFO[PASSWORD].pattern}
-              onChange={onChangeHandler}
-              ref={nextFieldId.current === `${PASSWORD}${1}` ? inputRef : null}
-            />{' '}
+            {INIT_CARD_STATE[PASSWORD].map((_, i) => (
+              <Fragment key={`${PASSWORD}${i}`}>
+                <Input
+                  type='password'
+                  className='w-15'
+                  data-index={i}
+                  data-id={PASSWORD}
+                  value={cardState[PASSWORD][i]}
+                  maxLength={INPUT_LENGTH[PASSWORD]}
+                  pattern={INPUT_INFO[PASSWORD].pattern}
+                  onChange={onChangeHandler}
+                  ref={
+                    nextFieldId.current === `${PASSWORD}${i}` ? inputRef : null
+                  }
+                />{' '}
+              </Fragment>
+            ))}
             <Input
               type='password'
               className='w-15'

--- a/src/pages/NewCard/index.tsx
+++ b/src/pages/NewCard/index.tsx
@@ -1,24 +1,21 @@
-import { useState } from 'react';
+import { useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { INIT_CARD_STATE } from '@/constants/index';
+import { CardContext } from '@/context/cardContext';
 import PageContainer from '@components/PageContainer';
 import PageTitle from '@components/PageTitle';
-import PageBottom, { PageBottomText } from '@components/PageBottom/index';
+
 import Button from '@components/Button';
 import Card from '@components/Card';
 import CardForm from '@/pages/NewCard/cardForm';
-import { changeCardStateType } from '@/pages/NewCard/type';
 
 const NewCard = () => {
+  const { cardState, setCardState } = useContext(CardContext);
   const navigate = useNavigate();
 
-  const [cardState, setCardState] = useState({ ...INIT_CARD_STATE });
-
-  const goListPage = () => navigate('../list');
-  const goDonePage = () => navigate('../done');
-
-  const changeCardState: changeCardStateType = (newState) => {
-    setCardState({ ...cardState, ...newState });
+  const goListPage = () => {
+    setCardState(INIT_CARD_STATE);
+    navigate('../list');
   };
 
   return (
@@ -30,12 +27,7 @@ const NewCard = () => {
         카드 추가
       </PageTitle>
       <Card {...cardState} />
-      <CardForm cardState={cardState} changeCardState={changeCardState} />
-      <PageBottom className='mt-auto'>
-        <Button onClick={goDonePage}>
-          <PageBottomText>다음</PageBottomText>
-        </Button>
-      </PageBottom>
+      <CardForm />
     </PageContainer>
   );
 };

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -17,6 +17,9 @@ const GlobalStyle = createGlobalStyle`
     border: 0 none;
     padding: 0;
   }
+  a {
+    text-decoration: none;
+  }
   ${utilsStyle}
   ${animationStyle}
 `;


### PR DESCRIPTION
민경님~ 안녕하세요!

새해복 많이 받으세요 :) 
설 잘보내고 늦게나마 올리네요~

이전 스텝에서 validation error 추가하기로 한 부분과
card form에서 input mapping,
그리고 스텝2 구현 내용 올립니다.

스토리북에 따로 더 추가한 내용은 없습니다.

확인 부탁드려요! 감사합니다. 😄

[데모페이지](https://glassyi.github.io/react-payments/)

## 필수 요구사항

- [x] Storybook 상호 작용 테스트
- [x] Controlled & Uncontrolled Components에 입각하여 Form 핸들링 -> 별칭 input을 Uncontrolled Components로 작성
- [x] Context API를 활용해 전역 상태 관리 및 계층 재구성

### 카드 추가 확인

- [x] 이전 폼에서 입력된 카드를 보여준다.
- [x] 카드 별칭을 입력할 수 있다.
  - [x] placeholder는 카드 별칭 (선택)이다.
  - [x] 빈 입력값인 경우, 카드사 이름이 별칭으로 저장된다.
  - [x] 최대 길이는 10자리이다.
- [x] 확인 버튼을 누르면, 카드 목록 페이지로 이동한다.

### 카드 목록

- [x] 카드 목록을 조회할 수 있다.
- [x] 카드 목록은 최신순(내림차순)으로 정렬된다.
- [x] 목록 최상단에 +을 누르면 카드 추가 페이지로 이동한다.
- [x] 카드를 클릭하면, 카드 별칭 수정(카드 추가 완료 페이지)로 이동한다.
- [x] 카드를 삭제할 수 있다.

### 선택 요구사항

- [ ] Storybook 스냅샷 테스트
- [ ] 비동기 통신
  - [ ] 다양한 도구를 활용 (예 JSON Server, Strapi 등등)
  - [ ] 등록된 카드 정보를 CRUD 합니다.
- [x] 나열된 카드 클릭시 카드 추가 확인 화면 재활용
  - [x] 별칭 수정 가능